### PR TITLE
Make the special first page case not depend on the page name

### DIFF
--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -1,6 +1,17 @@
-const processPagePath = page => {
-  if (!page) return null
-  return page.name === '00' ? '/' : `/${page.name}`
+const getPreviousPagePath = (page, currentPageIndex) => {
+  if (!page) return null;
+  if (currentPageIndex - 1 === 0) return '/';
+  return `/${page.name}`;
+}
+
+const getNextPagePath = page => {
+  if (!page) return null;
+  return `/${page.name}`;
+}
+
+const getCurrentPagePath = (page, currentPageIndex) => {
+  if (currentPageIndex === 0) return '/';
+  return `/${page.name}`;
 }
 
 exports.createPages = ({ graphql, actions }) => {
@@ -23,10 +34,10 @@ exports.createPages = ({ graphql, actions }) => {
         }
       }
     `).then(results => {
-      results.data.allFile.edges.forEach(({ next, node, previous }) => {
-        const currentPath = processPagePath(node)
-        const nextPage = processPagePath(next)
-        const previousPage = processPagePath(previous)
+      results.data.allFile.edges.forEach(({ next, node, previous }, index) => {
+        const currentPath = getCurrentPagePath(node, index)
+        const nextPage = getNextPagePath(next, index)
+        const previousPage = getPreviousPagePath(previous, index)
 
         createPage({
           path: currentPath,

--- a/theme/gatsby-node.js
+++ b/theme/gatsby-node.js
@@ -1,17 +1,17 @@
 const getPreviousPagePath = (page, currentPageIndex) => {
-  if (!page) return null;
-  if (currentPageIndex - 1 === 0) return '/';
-  return `/${page.name}`;
+  if (!page) return null
+  if (currentPageIndex - 1 === 0) return '/'
+  return `/${page.name}`
 }
 
 const getNextPagePath = page => {
-  if (!page) return null;
-  return `/${page.name}`;
+  if (!page) return null
+  return `/${page.name}`
 }
 
 const getCurrentPagePath = (page, currentPageIndex) => {
-  if (currentPageIndex === 0) return '/';
-  return `/${page.name}`;
+  if (currentPageIndex === 0) return '/'
+  return `/${page.name}`
 }
 
 exports.createPages = ({ graphql, actions }) => {


### PR DESCRIPTION
#20 did not strictly follow this from #6: 

> This way users of the theme can use whatever naming scheme they would like

This PR fixes that, by using the iterator index to determine if the special case "first page" should get the '/' slug.
